### PR TITLE
Change the save directory for emacs auto save to be temp folder isntead ...

### DIFF
--- a/home/_emacs.d/init.el
+++ b/home/_emacs.d/init.el
@@ -345,3 +345,11 @@
      (with-current-buffer buffer
        (buffer-string))))
   (message "Output copied to kill ring"))
+
+;;=====================================
+;;change auto save directory
+;;=====================================
+(setq backup-directory-alist
+  `((".*" . ,temporary-file-directory)))
+(setq auto-save-file-name-transforms
+  `((".*" ,temporary-file-directory t)))


### PR DESCRIPTION
...of current directory

Taken from 

http://emacswiki.org/emacs/AutoSave

I think this is a better solution that changing gulp tasks to regex exclude emacs temp files.  It even adds the path to the file name so that there aren't collisions of temporary files.